### PR TITLE
Add support for retrieving MacOS version.

### DIFF
--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,4 +1,4 @@
-// Update the code example in README.md whenver this example is changed.
+// Update the code example in README.md whenever this example is changed.
 
 use bugreport::{bugreport, collector::*, format::Markdown};
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -167,7 +167,44 @@ impl Collector for OperatingSystem {
             .as_ref()
             .map(|t| t.deref())
             .unwrap_or("(unknown version)");
+
+        #[cfg(target_os = "macos")]
+        return Ok(ReportEntry::Text(format!(
+            "{} ({} {})",
+            macos_info_string(),
+            os_type,
+            os_release
+        )));
+
+        #[cfg(not(target_os = "macos"))]
         Ok(ReportEntry::Text(format!("{} {}", os_type, os_release)))
+    }
+}
+
+#[cfg(all(feature = "collector_operating_system", target_os = "macos"))]
+fn macos_info() -> Result<(String, String)> {
+    fn sw_vers(arg: &str) -> Result<String> {
+        let stdout = Command::new("sw_vers")
+            .arg(arg)
+            .output()
+            .map_err(|err| CollectionError::CouldNotRetrieve(err.to_string()))?
+            .stdout;
+
+        Ok(String::from_utf8_lossy(&stdout).trim().to_owned())
+    }
+
+    let macos_name = sw_vers("-productName")?;
+    let macos_version = sw_vers("-productVersion")?;
+
+    Ok((macos_name, macos_version))
+}
+
+#[cfg(all(feature = "collector_operating_system", target_os = "macos"))]
+fn macos_info_string() -> String {
+    if let Ok((name, version)) = macos_info() {
+        format!("{} {}", name, version)
+    } else {
+        "Unknown".to_owned()
     }
 }
 


### PR DESCRIPTION
This pull request allows `bugreport` to find the user's MacOS version, which should help bring the new `--diagnostic` feature in `bat` more in line with the existing bash script.

## Format

Due to the way that MacOS has two version strings (MacOS version and Darwin version), I chose to use `#[cfg]` to offer an alternate format for displaying the operation system info: `{macos_name} {macos_version} ({os_type} {os_version})`

On my machine, it ends up looking like this:

```
Mac OS X 10.14.6 (Darwin 18.7.0)
```

## Implementation

Under the hood, it runs the `sw_vers` command to retrieve the system's product name and product info.

While a better implementation would be to use the [gestalt syscall](https://developer.apple.com/documentation/coreservices/1470788-system_version_selectors/gestaltsystemversion) and add the querying capabilities directly to the `sys-info` crate, I felt it would be better to at least have something here in the meantime.