### PR TITLE
Bump sys-info dependency version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,6 @@ format_markdown = []
 format_plaintext = []
 
 [dependencies]
-sys-info = { version = "0.7", optional = true }
+sys-info = { version = "0.9", optional = true }
 git-version = { version = "0.3", optional = true }
 snailquote = "0.3"


### PR DESCRIPTION
I'm creating this PR because the 0.8 version of sys-info fixes a bunch of bugs and notably a compilation error on Android.