### PR TITLE
SoftwareVersion: Add git hash suffix with git-version crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,12 @@ jobs:
           command: run
           args: --target ${{ matrix.job.target }} --example=simple -- "'test value' on command line" "two" "three"
       - uses: actions-rs/cargo@v1
+        name: "example 'simple' without git_hash feature"
+        with:
+          use-cross: ${{ matrix.job.use-cross }}
+          command: run
+          args: --target ${{ matrix.job.target }} --example=simple --no-default-features --features collector_operating_system,format_markdown
+      - uses: actions-rs/cargo@v1
         name: "example 'custom_collector'"
         with:
           use-cross: ${{ matrix.job.use-cross }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,16 @@ edition = "2018"
 version = "0.3.0"
 
 [features]
-default = ["collector_operating_system", "format_markdown"]
+default = ["collector_operating_system", "git_hash", "format_markdown"]
 
 collector_operating_system = ["sys-info"]
+
+git_hash = ["git-version"]
 
 format_markdown = []
 format_plaintext = []
 
 [dependencies]
 sys-info = { version = "0.7", optional = true }
+git-version = { version = "0.3", optional = true }
 snailquote = "0.3"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ generates bug report information that [looks like this](example-report.md).
 
 ## Collectors
 
-- [x] Crate information (name and version)
+- [x] Crate information (name, version, git hash)
 - [x] Operating system (type, name, version)
 - [x] Command line (including all arguments)
 - [x] Environment variables (e.g. `SHELL`, `PATH`, …)

--- a/example-report.md
+++ b/example-report.md
@@ -1,6 +1,6 @@
 #### Software version
 
-bugreport 0.3.0
+bugreport 0.3.0 a984113
 
 #### Operating system
 

--- a/example-report.md
+++ b/example-report.md
@@ -1,6 +1,6 @@
 #### Software version
 
-bugreport 0.3.0 a984113
+bugreport 0.3.0 (a984113)
 
 #### Operating system
 

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -59,7 +59,7 @@ impl Collector for SoftwareVersion {
 
     fn collect(&mut self, crate_info: &CrateInfo) -> Result<ReportEntry> {
         #[cfg(feature = "git_hash")]
-        let git_hash_suffix = format!(" {}", crate_info.git_hash);
+        let git_hash_suffix = format!(" ({})", crate_info.git_hash);
 
         #[cfg(not(feature = "git_hash"))]
         let git_hash_suffix = "";

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -58,10 +58,17 @@ impl Collector for SoftwareVersion {
     }
 
     fn collect(&mut self, crate_info: &CrateInfo) -> Result<ReportEntry> {
+        #[cfg(feature = "git_hash")]
+        let git_hash_suffix = format!(" {}", crate_info.git_hash);
+
+        #[cfg(not(feature = "git_hash"))]
+        let git_hash_suffix = "";
+
         Ok(ReportEntry::Text(format!(
-            "{} {}",
+            "{} {}{}",
             crate_info.pkg_name,
-            self.version.as_deref().unwrap_or(&crate_info.pkg_version)
+            self.version.as_deref().unwrap_or(&crate_info.pkg_version),
+            git_hash_suffix,
         )))
     }
 }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -58,11 +58,10 @@ impl Collector for SoftwareVersion {
     }
 
     fn collect(&mut self, crate_info: &CrateInfo) -> Result<ReportEntry> {
-        #[cfg(feature = "git_hash")]
-        let git_hash_suffix = format!(" ({})", crate_info.git_hash);
-
-        #[cfg(not(feature = "git_hash"))]
-        let git_hash_suffix = "";
+        let git_hash_suffix = match crate_info.git_hash {
+            Some(git_hash) => format!(" ({})", git_hash),
+            None => format!(""),
+        };
 
         Ok(ReportEntry::Text(format!(
             "{} {}{}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,29 +101,32 @@ impl<'a> BugReport<'a> {
 pub use git_version::git_version;
 
 #[cfg(feature = "git_hash")]
+#[doc(hidden)]
 #[macro_export]
+macro_rules! bugreport_set_git_hash {
+    ($br:ident) => {
+        $br.set_git_hash(Some(bugreport::git_version!(fallback = "<no git>")));
+    };
+}
+
+#[cfg(not(feature = "git_hash"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! bugreport_set_git_hash {
+    ($br:ident) => {};
+}
+
 /// Generate a new [`BugReport`] object.
+#[macro_export]
 macro_rules! bugreport {
     () => {{
         let mut br = bugreport::BugReport::from_name_and_version(
             env!("CARGO_PKG_NAME"),
             env!("CARGO_PKG_VERSION"),
         );
-        br.set_git_hash(Some(bugreport::git_version!(fallback = "<no git>")));
+        bugreport::bugreport_set_git_hash!(br);
         br
     }};
-}
-
-#[cfg(not(feature = "git_hash"))]
-#[macro_export]
-/// Generate a new [`BugReport`] object.
-macro_rules! bugreport {
-    () => {
-        bugreport::BugReport::from_name_and_version(
-            env!("CARGO_PKG_NAME"),
-            env!("CARGO_PKG_VERSION"),
-        )
-    };
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Since we add it to the `bugreport!()` macro, it will be evaluated in the
context of the dependant project, and give relevant git hash info.

Features:
* Optional via Cargo feature `"git_hash"`
* Prints `<no git>` as git hash if git is not on `PATH`
* Triggers rebuild if git hash (or index) change [1]

Note that since the `bugreport!()` macro is evaluated in the context of
the dependent project, it is not possible to use `#[cfg()]` inside of it.
So we have to have two different definitions of it depending on feature
`"git_hash"`.

[1] Via elegant `include_bytes!()` hack by **git-version** crate, see
https://github.com/fusion-engineering/rust-git-version/blob/v0.3.4/git-version-macro/src/lib.rs#L40

## Example output

From below [CI run](https://github.com/sharkdp/bugreport/pull/6/checks?check_run_id=2159002619)

### example 'simple'
```
#### Software version

bugreport 0.3.0 bf54af5
```

### example 'simple' without git_hash feature
```
#### Software version

bugreport 0.3.0
```

### bat using this version
From [CI run](https://github.com/Enselic/bat/runs/2159094644?check_suite_focus=true) for  https://github.com/Enselic/bat/commit/271db6681959bede8a6e60febbd57abb29578e2d
```
#### Software version

bat 0.18.0 271db66
```

### bat using this version but with "git_hash" feature disabled
From [CI run](https://github.com/Enselic/bat/runs/2159050826?check_suite_focus=true)  for https://github.com/Enselic/bat/commit/65a3d8135c08c4ae45839d4b19cb7a45868f7eb3
```
#### Software version

bat 0.18.0
```
