### PR TITLE
Silently ignore missing git repo, and add regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,17 +103,13 @@ jobs:
           command: run
           args: --target ${{ matrix.job.target }} --example=simple -- "'test value' on command line" "two" "three"
       - uses: actions-rs/cargo@v1
-        name: "example 'simple' without git_hash feature"
-        with:
-          use-cross: ${{ matrix.job.use-cross }}
-          command: run
-          args: --target ${{ matrix.job.target }} --example=simple --no-default-features --features collector_operating_system,format_markdown
-      - uses: actions-rs/cargo@v1
         name: "example 'custom_collector'"
         with:
           use-cross: ${{ matrix.job.use-cross }}
           command: run
           args: --target ${{ matrix.job.target }} --example=custom_collector -- "'test value' on command line" "two" "three"
+      - name: "test-crates tests"
+        run: ./test-crates/run-all-tests.sh
 
   fmt:
     name: Rustfmt

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,9 +104,12 @@ pub use git_version::git_version;
 #[doc(hidden)]
 #[macro_export]
 macro_rules! bugreport_set_git_hash {
-    ($br:ident) => {
-        $br.set_git_hash(Some(bugreport::git_version!(fallback = "<no git>")));
-    };
+    ($br:ident) => {{
+        let hash = bugreport::git_version!(fallback = "");
+        if !hash.is_empty() {
+            $br.set_git_hash(Some(hash));
+        }
+    }};
 }
 
 #[cfg(not(feature = "git_hash"))]

--- a/test-crates/README.md
+++ b/test-crates/README.md
@@ -1,0 +1,11 @@
+This directory contains crates used to test `bugreport`.
+
+It is insufficient to test bugreport with regular crate test facilities, due to
+how bugreport is implemented.
+
+Since bugreport uses a `bugreport!()` macro that is evaluated in the context of
+a dependent crate, it is important to test evaluation of that macro in an
+external create. Otherwise the test will not detect problems such as having
+`#[cfg(feature = "git_hash")]` inside the `bugreport!()` macro. Since the macro
+is evaluated in the context of the dependent crate, that feature will not be
+defined in that context.

--- a/test-crates/bugreport-client-with-git-hash-feature/.gitignore
+++ b/test-crates/bugreport-client-with-git-hash-feature/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/test-crates/bugreport-client-with-git-hash-feature/Cargo.toml
+++ b/test-crates/bugreport-client-with-git-hash-feature/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bugreport-client-with-git-hash-feature"
+description = "To test bugreport!() macro evaluation in a separate crate with git_hash."
+version = "0.1.0"
+authors = ["Martin Nordholts <enselic@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+bugreport = { path = "../..", default-features = false, features = ["git_hash", "format_markdown"] }
+bugreport-test-crate-utils = { path = "../bugreport-test-crate-utils" }

--- a/test-crates/bugreport-client-with-git-hash-feature/src/main.rs
+++ b/test-crates/bugreport-client-with-git-hash-feature/src/main.rs
@@ -1,0 +1,7 @@
+use bugreport::{bugreport, collector::*, format::Markdown};
+
+fn main() {
+    bugreport!()
+        .info(SoftwareVersion::default())
+        .print::<Markdown>();
+}

--- a/test-crates/bugreport-client-with-git-hash-feature/tests/integration_tests.rs
+++ b/test-crates/bugreport-client-with-git-hash-feature/tests/integration_tests.rs
@@ -1,0 +1,29 @@
+use bugreport_test_crate_utils::assert_bin_stdout;
+
+#[test]
+fn with_git_repo() {
+    assert_bin_stdout(
+        "bugreport-client-with-git-hash-feature",
+        r"#### Software version
+
+bugreport-client-with-git-hash-feature 0\.1\.0 \([0-9a-f]{7,}(-modified)?\)
+
+
+",
+    );
+}
+
+// NOTE: You must only run this test with GIT_DIR set to
+// something at build time that is not a git repo
+#[test]
+fn without_git_repo() {
+    assert_bin_stdout(
+        "bugreport-client-with-git-hash-feature",
+        r"#### Software version
+
+bugreport-client-with-git-hash-feature 0\.1\.0 \(<no git>\)
+
+
+",
+    );
+}

--- a/test-crates/bugreport-client-with-git-hash-feature/tests/integration_tests.rs
+++ b/test-crates/bugreport-client-with-git-hash-feature/tests/integration_tests.rs
@@ -21,7 +21,7 @@ fn without_git_repo() {
         "bugreport-client-with-git-hash-feature",
         r"#### Software version
 
-bugreport-client-with-git-hash-feature 0\.1\.0 \(<no git>\)
+bugreport-client-with-git-hash-feature 0\.1\.0
 
 
 ",

--- a/test-crates/bugreport-client-without-git-hash-feature/.gitignore
+++ b/test-crates/bugreport-client-without-git-hash-feature/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/test-crates/bugreport-client-without-git-hash-feature/Cargo.toml
+++ b/test-crates/bugreport-client-without-git-hash-feature/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bugreport-client-without-git-hash-feature"
+description = "To test bugreport!() macro evaluation in a separate crate without git_hash."
+version = "0.1.0"
+authors = ["Martin Nordholts <enselic@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+bugreport = { path = "../..", default-features = false, features = ["format_markdown"] }
+bugreport-test-crate-utils = { path = "../bugreport-test-crate-utils" }

--- a/test-crates/bugreport-client-without-git-hash-feature/src/main.rs
+++ b/test-crates/bugreport-client-without-git-hash-feature/src/main.rs
@@ -1,0 +1,7 @@
+use bugreport::{bugreport, collector::*, format::Markdown};
+
+fn main() {
+    bugreport!()
+        .info(SoftwareVersion::default())
+        .print::<Markdown>();
+}

--- a/test-crates/bugreport-client-without-git-hash-feature/tests/integration_tests.rs
+++ b/test-crates/bugreport-client-without-git-hash-feature/tests/integration_tests.rs
@@ -1,0 +1,29 @@
+use bugreport_test_crate_utils::assert_bin_stdout;
+
+#[test]
+fn with_git_repo() {
+    assert_bin_stdout(
+        "bugreport-client-without-git-hash-feature",
+        r"#### Software version
+
+bugreport-client-without-git-hash-feature 0\.1\.0
+
+
+",
+    );
+}
+
+// NOTE: You must only run this test with GIT_DIR set to
+// something at build time that is not a git repo
+#[test]
+fn without_git_repo() {
+    assert_bin_stdout(
+        "bugreport-client-without-git-hash-feature",
+        r"#### Software version
+
+bugreport-client-without-git-hash-feature 0\.1\.0
+
+
+",
+    );
+}

--- a/test-crates/bugreport-test-crate-utils/.gitignore
+++ b/test-crates/bugreport-test-crate-utils/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/test-crates/bugreport-test-crate-utils/Cargo.toml
+++ b/test-crates/bugreport-test-crate-utils/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "bugreport-test-crate-utils"
+version = "0.1.0"
+authors = ["Martin Nordholts <enselic@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+assert_cmd = "1.0"
+predicates = { version = "1.0", default-features = false, features = ["regex", "normalize-line-endings"] }

--- a/test-crates/bugreport-test-crate-utils/src/lib.rs
+++ b/test-crates/bugreport-test-crate-utils/src/lib.rs
@@ -1,0 +1,12 @@
+use std::process::Command as StdCommand;
+
+use predicates::prelude::*;
+
+use assert_cmd::cargo::CommandCargoExt;
+use assert_cmd::Command;
+
+pub fn assert_bin_stdout(bin: &str, regex: &str) {
+    Command::from_std(StdCommand::cargo_bin(bin).unwrap())
+        .assert()
+        .stdout(predicates::str::is_match(regex).unwrap().normalize());
+}

--- a/test-crates/run-all-tests.sh
+++ b/test-crates/run-all-tests.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset -o pipefail
+
+script_path="$(pwd)/$(dirname ${BASH_SOURCE})"
+
+test_crates="
+bugreport-client-with-git-hash-feature
+bugreport-client-without-git-hash-feature
+"
+
+for test_crate in ${test_crates}; do
+    cd ${script_path}/${test_crate}
+
+    # Test with a git repo (our own)
+    unset GIT_DIR
+    cargo clean -p ${test_crate}
+    cargo test with_git_repo
+
+    # Test without a git repo
+    export GIT_DIR=this-is-not-a-git-repo
+    cargo clean -p ${test_crate}
+    cargo test without_git_repo
+done


### PR DESCRIPTION
The first commit adds regression tests. See new `test-crates/README.md` for details

The second commit makes bugreport silently ignore missing git repo even with the git_hash feature enabled.

If an official release of a dependent project is built with e.g. `cargo install <name>`, there will be no git repo available. But that is OK, because an official release is built, so the git hash is uniquely determined by the release git tag.

So to keep output clean and to-the-point, silently skip printing git hash in this case.

See [this](https://github.com/sharkdp/bat/issues/1651#issuecomment-841426772) comment and related discussion for more background. 

