### PR TITLE
Fix clippy:derivable_impls and other lints

### DIFF
--- a/src/collector.rs
+++ b/src/collector.rs
@@ -305,11 +305,10 @@ impl<'a> Collector for CommandOutput<'a> {
 
         result.trim_end_inplace();
 
-        let mut concat = vec![];
-        concat.push(ReportEntry::Code(Code {
+        let mut concat = vec![ReportEntry::Code(Code {
             language: None,
             code: result,
-        }));
+        })];
 
         if !output.status.success() {
             concat.push(ReportEntry::Text(format!(

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -61,13 +61,13 @@ impl Collector for SoftwareVersion {
     fn collect(&mut self, crate_info: &CrateInfo) -> Result<ReportEntry> {
         let git_hash_suffix = match crate_info.git_hash {
             Some(git_hash) => format!(" ({})", git_hash),
-            None => format!(""),
+            None => String::new(),
         };
 
         Ok(ReportEntry::Text(format!(
             "{} {}{}",
             crate_info.pkg_name,
-            self.version.as_deref().unwrap_or(&crate_info.pkg_version),
+            self.version.as_deref().unwrap_or(crate_info.pkg_version),
             git_hash_suffix,
         )))
     }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -35,6 +35,7 @@ pub trait Collector {
 }
 
 /// The name of your crate and the current version.
+#[derive(Default)]
 pub struct SoftwareVersion {
     version: Option<String>,
 }
@@ -44,12 +45,6 @@ impl SoftwareVersion {
         Self {
             version: Some(version.as_ref().into()),
         }
-    }
-}
-
-impl Default for SoftwareVersion {
-    fn default() -> Self {
-        Self { version: None }
     }
 }
 
@@ -74,13 +69,8 @@ impl Collector for SoftwareVersion {
 }
 
 /// Compile-time information such as the profile (release/debug) and the target triple.
+#[derive(Default)]
 pub struct CompileTimeInformation {}
-
-impl Default for CompileTimeInformation {
-    fn default() -> Self {
-        Self {}
-    }
-}
 
 impl Collector for CompileTimeInformation {
     fn description(&self) -> &str {
@@ -118,13 +108,8 @@ impl Collector for CompileTimeInformation {
 }
 
 /// The full command-line: executable name and arguments to the program.
+#[derive(Default)]
 pub struct CommandLine {}
-
-impl Default for CommandLine {
-    fn default() -> Self {
-        Self {}
-    }
-}
 
 impl Collector for CommandLine {
     fn description(&self) -> &str {
@@ -148,14 +133,8 @@ impl Collector for CommandLine {
 
 /// The operating system (type and version).
 #[cfg(feature = "collector_operating_system")]
+#[derive(Default)]
 pub struct OperatingSystem {}
-
-#[cfg(feature = "collector_operating_system")]
-impl Default for OperatingSystem {
-    fn default() -> Self {
-        Self {}
-    }
-}
 
 #[cfg(feature = "collector_operating_system")]
 impl Collector for OperatingSystem {


### PR DESCRIPTION
Using https://github.com/Enselic/cargo-public-items we can easily see the impact on the public API of this change, and it is as follows:

```
% git checkout master
% cargo public-items > /tmp/master
% git checkout fix-some-lints
% cargo public-items > /tmp/pr
% diff -U0 /tmp/master /tmp/pr
--- /tmp/before	2022-02-28 21:10:55.000000000 +0100
+++ /tmp/after	2022-02-28 21:10:44.000000000 +0100
@@ -15 +15 @@
-pub fn bugreport::collector::CommandLine::default() -> Self
+pub fn bugreport::collector::CommandLine::default() -> CommandLine
@@ -21 +21 @@
-pub fn bugreport::collector::CompileTimeInformation::default() -> Self
+pub fn bugreport::collector::CompileTimeInformation::default() -> CompileTimeInformation
@@ -30 +30 @@
-pub fn bugreport::collector::OperatingSystem::default() -> Self
+pub fn bugreport::collector::OperatingSystem::default() -> OperatingSystem
@@ -34 +34 @@
-pub fn bugreport::collector::SoftwareVersion::default() -> Self
+pub fn bugreport::collector::SoftwareVersion::default() -> SoftwareVersion
```

and as we can see the only difference is that the return type has changed from `Self` to explicit types, which is equivalent to the current public API.