### PR TITLE
New collector `DirectoryEntries`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ format_plaintext = []
 sys-info = { version = "0.9", optional = true }
 git-version = { version = "0.3", optional = true }
 shell-escape = "0.1"
+
+[dev-dependencies]
+pretty_assertions = "1.1.0"
+tempfile = "3.3.0"

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ generates bug report information that [looks like this](example-report.md).
 - [x] Command line (including all arguments)
 - [x] Environment variables (e.g. `SHELL`, `PATH`, …)
 - [x] File contents (e.g. config files)
+- [x] Directory contents
 - [x] Command output (e.g. `bash --version`)
 - [x] Compile time information (profile, target, architecture, cpu features, etc.)
 - [ ] Current working directory

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -12,6 +12,9 @@ use super::Result;
 use crate::helper::StringExt;
 use crate::report::{Code, ReportEntry};
 
+mod directory_entries;
+pub use directory_entries::DirectoryEntries;
+
 /// Error that appeared while collecting bug report information.
 #[derive(Debug)]
 pub enum CollectionError {

--- a/src/collector/directory_entries.rs
+++ b/src/collector/directory_entries.rs
@@ -1,0 +1,88 @@
+use std::fs::{self, DirEntry};
+use std::io::ErrorKind;
+use std::path::PathBuf;
+
+use crate::{report::ReportEntry, Collector, CrateInfo, Result};
+
+use super::CollectionError;
+
+/// List information about entries in a directory.
+///
+/// Limitations:
+/// * Is not recursive
+/// * Does not handle symbolic links
+/// * Only sizes of files are printed and not e.g. time of last modification
+///
+/// # Example
+///
+/// ```md
+/// #### File and dir
+///
+/// - file.txt, 14 bytes
+/// - some_dir
+///
+/// ```
+pub struct DirectoryEntries {
+    title: String,
+    path: PathBuf,
+}
+
+impl DirectoryEntries {
+    pub fn new(title: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+        Self {
+            title: title.into(),
+            path: path.into(),
+        }
+    }
+}
+
+impl Collector for DirectoryEntries {
+    fn description(&self) -> &str {
+        &self.title
+    }
+
+    fn collect(&mut self, _: &CrateInfo) -> Result<ReportEntry> {
+        let path_str = &self.path.to_string_lossy();
+
+        let mut entries = fs::read_dir(&self.path)
+            .map_err(|e| read_dir_error_to_report_entry(e, path_str))?
+            .map(|e| match e {
+                Ok(dir_entry) => dir_entry_to_report_entry(dir_entry),
+                Err(e) => format!("Error: {}", e),
+            })
+            .collect::<Vec<_>>();
+
+        // For stable ordering
+        entries.sort();
+
+        if entries.is_empty() {
+            Ok(ReportEntry::Text(format!("'{}' is empty", path_str)))
+        } else {
+            Ok(ReportEntry::List(
+                entries.into_iter().map(ReportEntry::Text).collect(),
+            ))
+        }
+    }
+}
+
+fn read_dir_error_to_report_entry(error: std::io::Error, path_str: &str) -> CollectionError {
+    CollectionError::CouldNotRetrieve(if error.kind() == ErrorKind::NotFound {
+        format!("'{}' not found", path_str)
+    } else {
+        format!("'{}' not read: {}", path_str, error)
+    })
+}
+
+fn dir_entry_to_report_entry(dir_entry: DirEntry) -> String {
+    let mut text = String::new();
+
+    text.push_str(&dir_entry.file_name().to_string_lossy());
+
+    if let Ok(metadata) = dir_entry.metadata() {
+        if metadata.is_file() {
+            text.push_str(&format!(", {} bytes", metadata.len()));
+        }
+    }
+
+    text
+}

--- a/src/collector/directory_entries.rs
+++ b/src/collector/directory_entries.rs
@@ -10,7 +10,7 @@ use super::CollectionError;
 ///
 /// Limitations:
 /// * Is not recursive
-/// * Does not handle symbolic links
+/// * Does not follow symbolic links
 /// * Only sizes of files are printed and not e.g. time of last modification
 ///
 /// # Example
@@ -19,7 +19,8 @@ use super::CollectionError;
 /// #### File and dir
 ///
 /// - file.txt, 14 bytes
-/// - some_dir
+/// - some_dir/
+/// - symlink_to_file.txt@
 ///
 /// ```
 pub struct DirectoryEntries {
@@ -81,6 +82,10 @@ fn dir_entry_to_report_entry(dir_entry: DirEntry) -> String {
     if let Ok(metadata) = dir_entry.metadata() {
         if metadata.is_file() {
             text.push_str(&format!(", {} bytes", metadata.len()));
+        } else if metadata.is_dir() {
+            text.push(std::path::MAIN_SEPARATOR);
+        } else if metadata.is_symlink() {
+            text.push('@');
         }
     }
 

--- a/src/collector/directory_entries.rs
+++ b/src/collector/directory_entries.rs
@@ -84,8 +84,11 @@ fn dir_entry_to_report_entry(dir_entry: DirEntry) -> String {
             text.push_str(&format!(", {} bytes", metadata.len()));
         } else if metadata.is_dir() {
             text.push(std::path::MAIN_SEPARATOR);
-        } else if metadata.is_symlink() {
-            text.push('@');
+        } else {
+            #[cfg(unix)]
+            if metadata.is_symlink() {
+                text.push('@');
+            }
         }
     }
 

--- a/src/collector/directory_entries.rs
+++ b/src/collector/directory_entries.rs
@@ -10,7 +10,7 @@ use super::CollectionError;
 ///
 /// Limitations:
 /// * Is not recursive
-/// * Does not follow symbolic links
+/// * Does not handle symbolic links
 /// * Only sizes of files are printed and not e.g. time of last modification
 ///
 /// # Example
@@ -20,7 +20,6 @@ use super::CollectionError;
 ///
 /// - file.txt, 14 bytes
 /// - some_dir/
-/// - symlink_to_file.txt@
 ///
 /// ```
 pub struct DirectoryEntries {
@@ -84,11 +83,6 @@ fn dir_entry_to_report_entry(dir_entry: DirEntry) -> String {
             text.push_str(&format!(", {} bytes", metadata.len()));
         } else if metadata.is_dir() {
             text.push(std::path::MAIN_SEPARATOR);
-        } else {
-            #[cfg(unix)]
-            if metadata.is_symlink() {
-                text.push('@');
-            }
         }
     }
 

--- a/src/collector/directory_entries.rs
+++ b/src/collector/directory_entries.rs
@@ -1,6 +1,6 @@
 use std::fs::{self, DirEntry};
 use std::io::ErrorKind;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::{report::ReportEntry, Collector, CrateInfo, Result};
 
@@ -27,11 +27,11 @@ pub struct DirectoryEntries {
     path: PathBuf,
 }
 
-impl DirectoryEntries {
-    pub fn new(title: impl Into<String>, path: impl Into<PathBuf>) -> Self {
+impl<'a> DirectoryEntries {
+    pub fn new<P: AsRef<Path>>(title: &'a str, path: P) -> Self {
         Self {
             title: title.into(),
-            path: path.into(),
+            path: path.as_ref().to_path_buf(),
         }
     }
 }

--- a/tests/test_collector_directory_entries.rs
+++ b/tests/test_collector_directory_entries.rs
@@ -87,6 +87,10 @@ fn dir_exists() -> Result<(), std::io::Error> {
         expected = expected.replace("- symlink_to_file.txt@", "");
         expected.pop(); // .replace() does not handle newlines so remove last newline here
     }
+    #[cfg(windows)]
+    {
+        expected = expected.replace("some_dir/", "some_dir\\");
+    }
 
     assert_eq!(expected, actual);
 

--- a/tests/test_collector_directory_entries.rs
+++ b/tests/test_collector_directory_entries.rs
@@ -1,0 +1,90 @@
+#![cfg(feature = "format_markdown")]
+
+use std::path::PathBuf;
+
+use pretty_assertions::assert_eq;
+use tempfile::tempdir;
+
+use bugreport::{bugreport, collector::DirectoryEntries, format::Markdown};
+
+#[test]
+fn dir_not_found() {
+    let actual = bugreport!()
+        .info(DirectoryEntries::new("No dir", "this-dir-does-not-exist"))
+        .format::<Markdown>();
+
+    let expected = "#### No dir
+
+'this-dir-does-not-exist' not found
+
+";
+
+    assert_eq!(expected, actual);
+}
+
+#[test]
+fn dir_is_empty() -> Result<(), std::io::Error> {
+    let empty_dir = tempdir()?;
+    let empty_dir_path = empty_dir.path();
+
+    let actual = bugreport!()
+        .info(DirectoryEntries::new("Empty dir", empty_dir_path))
+        .format::<Markdown>();
+
+    let expected = format!(
+        "#### Empty dir
+
+'{}' is empty
+
+",
+        empty_dir_path.to_string_lossy()
+    );
+
+    assert_eq!(expected, actual);
+
+    Ok(())
+}
+
+#[test]
+fn dir_exists() -> Result<(), std::io::Error> {
+    let dir = tempdir()?;
+    let dir_path = dir.path();
+
+    // Put a file in the dir
+    let mut some_file = PathBuf::from(dir_path);
+    some_file.push("file.txt");
+    std::fs::write(some_file, "This is a file")?;
+
+    // Put a dir in the dir
+    let mut some_dir = PathBuf::from(dir_path);
+    some_dir.push("some_dir");
+    std::fs::create_dir(some_dir)?;
+
+    let actual = bugreport!()
+        .info(DirectoryEntries::new("File and dir", dir_path))
+        .format::<Markdown>();
+
+    let expected = "#### File and dir
+
+- file.txt, 14 bytes
+- some_dir
+
+";
+
+    assert_eq!(expected, actual);
+
+    Ok(())
+}
+
+#[test]
+fn new() {
+    DirectoryEntries::new("a", "/a");
+    DirectoryEntries::new(String::from("b"), PathBuf::from("/b"));
+    DirectoryEntries::new(&String::from("c"), &PathBuf::from("/c"));
+    new_with_title_from_local_variable();
+}
+
+fn new_with_title_from_local_variable() -> DirectoryEntries {
+    let local_variable = String::from("pretend this is dynamically constructed");
+    DirectoryEntries::new(&local_variable, "/path")
+}

--- a/tests/test_collector_directory_entries.rs
+++ b/tests/test_collector_directory_entries.rs
@@ -53,19 +53,12 @@ fn dir_exists() -> Result<(), std::io::Error> {
     // Put a file in the dir
     let mut some_file = PathBuf::from(dir_path);
     some_file.push("file.txt");
-    std::fs::write(&some_file, "This is a file")?;
+    std::fs::write(some_file, "This is a file")?;
 
     // Put a dir in the dir
     let mut some_dir = PathBuf::from(dir_path);
     some_dir.push("some_dir");
     std::fs::create_dir(some_dir)?;
-
-    #[cfg(unix)]
-    {
-        let mut some_symlink = PathBuf::from(dir_path);
-        some_symlink.push("symlink_to_file.txt");
-        std::os::unix::fs::symlink(&some_file, some_symlink)?;
-    }
 
     let actual = bugreport!()
         .info(DirectoryEntries::new("File and dir", dir_path))
@@ -77,16 +70,10 @@ fn dir_exists() -> Result<(), std::io::Error> {
 
 - file.txt, 14 bytes
 - some_dir/
-- symlink_to_file.txt@
 
 ",
     );
 
-    #[cfg(not(unix))]
-    {
-        expected = expected.replace("- symlink_to_file.txt@", "");
-        expected.pop(); // .replace() does not handle newlines so remove last newline here
-    }
     #[cfg(windows)]
     {
         expected = expected.replace("some_dir/", "some_dir\\");

--- a/tests/test_collector_directory_entries.rs
+++ b/tests/test_collector_directory_entries.rs
@@ -79,7 +79,7 @@ fn dir_exists() -> Result<(), std::io::Error> {
 #[test]
 fn new() {
     DirectoryEntries::new("a", "/a");
-    DirectoryEntries::new(String::from("b"), PathBuf::from("/b"));
+    // Not possible yet: DirectoryEntries::new(String::from("b"), PathBuf::from("/b"));
     DirectoryEntries::new(&String::from("c"), &PathBuf::from("/c"));
     new_with_title_from_local_variable();
 }


### PR DESCRIPTION
The use case I have in mind is to add info about custom assets to bat. If we add this line to bat:

```
        .info(DirectoryEntries::new("Custom assets", PROJECT_DIRS.cache_dir()))
```

we will get output in `--diagnostics` that look like this if custom assets are installed:

```
#### Custom assets

- metadata.yaml, 101 bytes
- syntaxes.bin, 726517 bytes
- themes.bin, 40475 bytes
```

and like this

```
#### Custom assets

'/Users/martin/.cache/bat' not found

```

or this

```
#### Custom assets

'/Users/martin/.cache/bat' is empty

```

if no custom assets are installed.

I took some liberties in the structure and interface of the new collector.
* I put it in its own file to make it easier to work with
* I made the title owned rather than referenced so that e.g. a collector can be constructed in a helper function with the title from a local var in the function. See `new_with_title_from_local_variable()` example in tests. That code does not work for e.g. `FileContents`.
* I used the "impl trait" syntax for clarity

I still made the new collector appear in the right place in the module hierarchy though, as can be demonstrated with `cargo public-items`:

```
% cargo public-items | grep -e DirectoryEntries -e FileContent
 Documenting bugreport v0.4.1 (/Users/martin/src/bugreport)
    Finished dev [unoptimized + debuginfo] target(s) in 0.28s
pub fn bugreport::collector::DirectoryEntries::collect(&mut self, _: &CrateInfo<'_>) -> result::Result<ReportEntry, CollectionError>
pub fn bugreport::collector::DirectoryEntries::description(&self) -> &str
pub fn bugreport::collector::DirectoryEntries::new(title: impl Into<String>, path: impl Into<PathBuf>) -> Self
pub fn bugreport::collector::FileContent::collect(&mut self, _: &CrateInfo<'_>) -> result::Result<ReportEntry, CollectionError>
pub fn bugreport::collector::FileContent::description(&self) -> &str
pub fn bugreport::collector::FileContent::new<P: AsRef<Path>>(title: &'a str, path: P) -> Self
pub struct bugreport::collector::DirectoryEntries
pub struct bugreport::collector::FileContent<'a>
```

or just a quick look at the `cargo doc` HTML if you're old-school :)

This is pretty bare-bones in terms of functionality (see docs in the code for limitations and idea for future improvements) but it should suit the bat use case well.
