### PR TITLE
CI: Remove ubuntu-16.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,11 @@
-on: [push, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
 
 name: Build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
           - { os: ubuntu-20.04   , target: i686-unknown-linux-musl     , use-cross: true  }
           # Older Ubuntu versions
           - { os: ubuntu-18.04   , target: x86_64-unknown-linux-gnu    , use-cross: false }
-          - { os: ubuntu-16.04   , target: x86_64-unknown-linux-gnu    , use-cross: false }
           # MacOS
           - { os: macos-10.15    , target: x86_64-apple-darwin         , use-cross: false }
           # Windows


### PR DESCRIPTION
commit 47233523a42ebe3caef04710a3dd5900e69ba3a8

    ci.yml: Remove ubuntu-16.04 that never starts
    
    Probably because it is too old and has been decommissioned by GitHub.

commit d4e4bbf15bee2f3874fccda32fff2b7e845e422a

    ci.yml: Don't trigger on push to every branch
    
    Ue same triggers as bat, namely PRs against any branch, but only pushes
    against master. And also allow manually starting a job. And trigger for
    tags (even though they are currently not special like in bat).
