### PR TITLE
Replace `sys-info` with `sysinfo` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ version = "0.5.0"
 [features]
 default = ["collector_operating_system", "git_hash", "format_markdown"]
 
-collector_operating_system = ["sys-info"]
+collector_operating_system = ["dep:sysinfo"]
 
 git_hash = ["git-version"]
 
@@ -27,7 +27,7 @@ format_markdown = []
 format_plaintext = []
 
 [dependencies]
-sys-info = { version = "0.9", optional = true }
+sysinfo = { version = "0.33.1", optional = true }
 git-version = { version = "0.3", optional = true }
 shell-escape = "0.1"
 

--- a/example-report.md
+++ b/example-report.md
@@ -4,7 +4,8 @@ bugreport 0.4.0 (4687617)
 
 #### Operating system
 
-Linux (Ubuntu 24.04)
+- OS: Linux (Ubuntu 24.04)
+- Kernel: 6.8.0-48-generic
 
 #### Command-line
 

--- a/example-report.md
+++ b/example-report.md
@@ -4,7 +4,7 @@ bugreport 0.4.0 (4687617)
 
 #### Operating system
 
-Linux 5.11.14-arch1-1
+Linux (Ubuntu 24.04)
 
 #### Command-line
 
@@ -37,5 +37,3 @@ Python 3.9.3
 - Endian: little
 - CPU features: fxsr,sse,sse2
 - Host: x86_64-unknown-linux-gnu
-
-

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -147,9 +147,16 @@ impl Collector for OperatingSystem {
     }
 
     fn collect(&mut self, _: &CrateInfo) -> Result<ReportEntry> {
-        Ok(ReportEntry::Text(
-            sysinfo::System::long_os_version().unwrap_or_else(|| "Unknown".to_owned()),
-        ))
+        Ok(ReportEntry::List(vec![
+            ReportEntry::Text(format!(
+                "OS: {}",
+                sysinfo::System::long_os_version().unwrap_or_else(|| "Unknown".to_owned()),
+            )),
+            ReportEntry::Text(format!(
+                "Kernel: {}",
+                sysinfo::System::kernel_version().unwrap_or_else(|| "Unknown".to_owned()),
+            )),
+        ]))
     }
 }
 


### PR DESCRIPTION
Closes #16 :

> Rumors say `cargo install bat` is failing for some people due to [a compilation failure from the `sys-info` crate](https://github.com/FillZpp/sys-info-rs/issues/116). However [the fix](https://github.com/FillZpp/sys-info-rs/pull/118) has not been merged for over half a year and the crate itself hasn't been active for over 2 years now.
> 
> There is an alternative crate [`sysinfo`](https://github.com/GuillaumeGomez/sysinfo) that's more regularly maintained and I believe it should provide similar functionality needed by this project.

---

Examples copied from [`sysinfo::System::long_os_version`](https://docs.rs/sysinfo/latest/sysinfo/struct.System.html#method.long_os_version)'s documentation:

| example platform | value of `System::long_os_version()` |
|---|---|
| linux laptop | "Linux (Ubuntu 24.04)" |
| android phone | "Android 15 on Pixel 9 Pro" |
| apple laptop | "macOS 15.1.1 Sequoia" |
| windows server | "Windows Server 2022 Datacenter" |

I can add the kernel version information too if someone can give suggestions on how to format them together.

---

EDIT:

~~This PR depends on the MSRV bump to 1.74 proposed in #18.~~ merged.

A more comprehensive list of outputs is also available in a successful action run based on #18:
https://github.com/sola-contrib/bugreport/actions/runs/12552288110