### PR TITLE
Fix CI issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,22 +66,34 @@ jobs:
       fail-fast: false
       matrix:
         job:
+          # Ubuntu 22.04
+          - { os: ubuntu-22.04 , target: x86_64-unknown-linux-gnu    , use-cross: false }
+          - { os: ubuntu-22.04 , target: x86_64-unknown-linux-musl   , use-cross: true }
+          - { os: ubuntu-22.04 , target: arm-unknown-linux-gnueabihf , use-cross: true }
+          - { os: ubuntu-22.04 , target: aarch64-unknown-linux-gnu   , use-cross: true }
+          - { os: ubuntu-22.04 , target: i586-unknown-linux-gnu      , use-cross: true }
+          - { os: ubuntu-22.04 , target: i686-unknown-linux-gnu      , use-cross: true }
+          - { os: ubuntu-22.04 , target: i686-unknown-linux-musl     , use-cross: true }
           # Ubuntu 20.04
-          - { os: ubuntu-20.04   , target: x86_64-unknown-linux-gnu    , use-cross: false }
-          - { os: ubuntu-20.04   , target: x86_64-unknown-linux-musl   , use-cross: true  }
-          - { os: ubuntu-20.04   , target: arm-unknown-linux-gnueabihf , use-cross: true  }
-          - { os: ubuntu-20.04   , target: aarch64-unknown-linux-gnu   , use-cross: true  }
-          - { os: ubuntu-20.04   , target: i586-unknown-linux-gnu      , use-cross: true  }
-          - { os: ubuntu-20.04   , target: i686-unknown-linux-gnu      , use-cross: true  }
-          - { os: ubuntu-20.04   , target: i686-unknown-linux-musl     , use-cross: true  }
-          # Older Ubuntu versions
-          - { os: ubuntu-18.04   , target: x86_64-unknown-linux-gnu    , use-cross: false }
-          # MacOS
-          - { os: macos-10.15    , target: x86_64-apple-darwin         , use-cross: false }
-          # Windows
-          - { os: windows-2019   , target: i686-pc-windows-msvc        , use-cross: false }
-          - { os: windows-2019   , target: x86_64-pc-windows-gnu       , use-cross: false }
-          - { os: windows-2019   , target: x86_64-pc-windows-msvc      , use-cross: false }
+          - { os: ubuntu-20.04 , target: x86_64-unknown-linux-gnu    , use-cross: false }
+          - { os: ubuntu-20.04 , target: x86_64-unknown-linux-musl   , use-cross: true }
+          - { os: ubuntu-20.04 , target: arm-unknown-linux-gnueabihf , use-cross: true }
+          - { os: ubuntu-20.04 , target: aarch64-unknown-linux-gnu   , use-cross: true }
+          - { os: ubuntu-20.04 , target: i586-unknown-linux-gnu      , use-cross: true }
+          - { os: ubuntu-20.04 , target: i686-unknown-linux-gnu      , use-cross: true }
+          - { os: ubuntu-20.04 , target: i686-unknown-linux-musl     , use-cross: true }
+          # MacOS 14
+          - { os: macos-14     , target: aarch64-apple-darwin        , use-cross: false }
+          # Macos 13
+          - { os: macos-13     , target: x86_64-apple-darwin         , use-cross: false }
+          # Windows 2022
+          - { os: windows-2022 , target: i686-pc-windows-msvc        , use-cross: false }
+          - { os: windows-2022 , target: x86_64-pc-windows-gnu       , use-cross: false }
+          - { os: windows-2022 , target: x86_64-pc-windows-msvc      , use-cross: false }
+          # Windows 2019
+          - { os: windows-2019 , target: i686-pc-windows-msvc        , use-cross: false }
+          - { os: windows-2019 , target: x86_64-pc-windows-gnu       , use-cross: false }
+          - { os: windows-2019 , target: x86_64-pc-windows-msvc      , use-cross: false }
 
     runs-on: ${{ matrix.job.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.43.0
+          - 1.74.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -37,7 +37,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.43.0
+          - 1.74.0
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
@@ -125,7 +125,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.43.0
+          toolchain: 1.74.0
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
@@ -142,7 +142,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.43.0
+          toolchain: 1.74.0
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -2,6 +2,7 @@
 
 use std::borrow::Cow;
 use std::ffi::{OsStr, OsString};
+use std::fmt::Write;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -219,12 +220,13 @@ impl Collector for EnvironmentVariables {
         let mut result = String::new();
 
         for var in &self.list {
-            let value = std::env::var_os(&var).map(|value| value.to_string_lossy().into_owned());
+            let value = std::env::var_os(var).map(|value| value.to_string_lossy().into_owned());
             let value: Option<String> =
                 value.map(|v| shell_escape::escape(Cow::Borrowed(&v)).into());
 
-            result += &format!(
-                "{}={}\n",
+            let _ = writeln!(
+                result,
+                "{}={}",
                 var.to_string_lossy(),
                 value.unwrap_or_else(|| "<not set>".into())
             );

--- a/src/collector/directory_entries.rs
+++ b/src/collector/directory_entries.rs
@@ -1,3 +1,4 @@
+use std::fmt::Write;
 use std::fs::{self, DirEntry};
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
@@ -80,7 +81,7 @@ fn dir_entry_to_report_entry(dir_entry: DirEntry) -> String {
 
     if let Ok(metadata) = dir_entry.metadata() {
         if metadata.is_file() {
-            text.push_str(&format!(", {} bytes", metadata.len()));
+            let _ = write!(text, ", {} bytes", metadata.len());
         } else if metadata.is_dir() {
             text.push(std::path::MAIN_SEPARATOR);
         }


### PR DESCRIPTION
This PR fixes various CI issues for my other PR #17.

### Changes

#### Updated Runner Images

GitHub Action no longer offers `macos-10.15` and `ubuntu-18.04` images. Jobs that depend on these images are no longer schedulable. This PR updates the runner images to what's currently available according to [this documentation](https://github.com/actions/runner-images).

#### Bump MSRV to 1.74.0

I ran into this [strange issue](https://github.com/sola-contrib/bugreport/actions/runs/12551564715/job/34996187540) when trying to build the current master with Rust 1.43, but not for the current stable version.

The version 1.74 is chosen to pave the path for #17 as the `sysinfo` crate we are replacing with [requires MSRV 1.74](https://github.com/GuillaumeGomez/sysinfo/blob/c491e0a23509ecfacd228352698d25b73d75342f/Cargo.toml#L9)

#### Resolve Clippy Warnings

The bumped MSRV also comes with newer lints/warnings, this PR also includes the fixes suggested by Clippy to make CI pass.

Lints fixed:
- [clippy::format_push_string](https://rust-lang.github.io/rust-clippy/master/index.html#format_push_string)
- [clippy::needless_borrows_for_generic_args](https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args)

---

Here is a successful action run from my forked repo with changes in this PR: https://github.com/sola-contrib/bugreport/actions/runs/12552120598